### PR TITLE
Static exported functions

### DIFF
--- a/buffertools.js
+++ b/buffertools.js
@@ -1,8 +1,22 @@
-buffertools = require('./buffertools.node');
-SlowBuffer = require('buffer').SlowBuffer;
-Buffer = require('buffer').Buffer;
+var buffertools = require('./buffertools.node');
+var SlowBuffer = require('buffer').SlowBuffer;
+var Buffer = require('buffer').Buffer;
+
+var slice = Array.prototype.slice;
 
 // extend object prototypes
-for (var property in buffertools) {
-	exports[property] = Buffer.prototype[property] = SlowBuffer.prototype[property] = buffertools[property];
-}
+Object.keys(buffertools).forEach(function(property) {
+
+  // the globally extended 'prototype's
+  // TODO: figure out a way to do this on a per-module basis
+  Buffer.prototype[property] = SlowBuffer.prototype[property] = buffertools[property];
+
+  // export a 'static' version of the helper function, where the
+  // 'this' Buffer is passed as the first argument instead
+  exports[property] = function() {
+    var buffer = arguments[0];
+    var args = slice.call(arguments, 1);
+    return buffertools[property].apply(buffer, args);
+  }
+
+});


### PR DESCRIPTION
This patch makes it so that the functions returned from the `require` call are 'static', in the sense that you pass the 'this' Buffer instance as the first argument.

This is, I think, the first step in getting #4 done.

Though it should be noted that until #6 is fixed, this change extends the glitch found there to the static version, such that, no matter which method you use to call `concat()`, the first argument is always going to be disregarded.
