### PR TITLE
Fix for Buffer::toHex table lookup overflow

### DIFF
--- a/buffertools.cc
+++ b/buffertools.cc
@@ -228,7 +228,7 @@ struct ToHexAction: UnaryAction<ToHexAction> {
 		std::string s(size * 2, 0);
 		for (size_t i = 0; i < size; ++i) {
 			const int c = data[i];
-			s[i * 2] = toHexTable[c >> 4];
+			s[i * 2] = toHexTable[(c >> 4) & 15];
 			s[i * 2 + 1] = toHexTable[c & 15];
 		}
 


### PR DESCRIPTION
I noticed that Buffer::toHex() was randomly missing characters. Investigation showed that it was always the upper nibble that was missing and that it was always replaced by a null byte when it was missing.

Tested with: Latest node.js 5.0.0-pre from git

Steps to reproduce:

```
# node
> new Buffer(4).toHex()
'7b103f18'
> new Buffer(4).toHex()
'\u00000\u0000d\u0000609'
> new Buffer(4).toHex()
'61600000'
> new Buffer(4).toHex()
'\u00008472800'
```

With patch:

```
# node
> new Buffer(4).toHex()
'81e20000'
> new Buffer(4).toHex()
'00ff7416'
> new Buffer(4).toHex()
'8d591b81'
> new Buffer(4).toHex()
'e100e0ff'
```

I assume that Buffer::data is no longer a char array in latest node? Whatever the case may be I think the patch makes sense anyway, sanitizing that table lookup is a good idea.
