### PR TITLE
Modified build system to support NPM 1.0.

### DIFF
--- a/buffertools.js
+++ b/buffertools.js
@@ -1,4 +1,4 @@
-buffertools = require('./buffertools.node');
+buffertools = require('./build/default/buffertools.node');
 SlowBuffer = require('buffer').SlowBuffer;
 Buffer = require('buffer').Buffer;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "buffertools",
-	"main": "build/default/buffertools",
+	"main": "buffertools",
 	"version": "1.0.0",
 	"keywords": ["buffer", "buffers"],
 	"description": "Working with node.js buffers made easy.",

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-buffertools = require('buffertools');
+buffertools = require('./buffertools');
 Buffer = require('buffer').Buffer;
 assert = require('assert');
 

--- a/wscript
+++ b/wscript
@@ -11,4 +11,3 @@ def build(ctx):
 	t = ctx.new_task_gen('cxx', 'shlib', 'node_addon')
 	t.target = 'buffertools'
 	t.source = 'buffertools.cc'
-	ctx.install_files('${NODE_PATH}', 'buffertools.js')


### PR DESCRIPTION
I noticed that node-buffertools did not work with NPM 1.0. After investigating the problem I found out that NPM 1.0 loads the native module instead of the buffertools.js.

The reason for this is that the package.json actually defines the native module as the entry point, which is incorrect.

It worked anyway in previous versions of NPM because the build script tries to install node-buffertools into the global namespace which is also not good.

Finally, the test.js also relies on buffertools to be installed globally, which is usually not what you want. During development you want to test your local version.

The attached commit addresses these issues and thereby fixes node-buffertools for NPM 1.0.
