### PR TITLE
Fix NPM package: Don't include binary

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+buffertools.node


### PR DESCRIPTION
It looks like the current package includes the buffertools.node binary:

http://registry.npmjs.org/buffertools/-/buffertools-1.0.5.tgz

This is causing issues on 32-bit systems:

https://github.com/bitcoinjs/node-bitcoin-exit/issues/6

I'm not totally sure about any of this. I _think_ the inclusion of buffertools.node is bad and I _think_ this npmignore should fix it. But please apply critical thinking to both claims. :)
