### PR TITLE
Incorrect build for wscript

### DIFF
--- a/wscript
+++ b/wscript
@@ -6,6 +6,7 @@ def set_options(ctx):
 def configure(ctx):
 	ctx.check_tool('compiler_cxx')
 	ctx.check_tool('node_addon')
+	ctx.env.set_variant('Release')
 
 def build(ctx):
 	t = ctx.new_task_gen('cxx', 'shlib', 'node_addon')


### PR DESCRIPTION
buffertools.js requires the buffertools.node file to be in the 'build/Require'.  By default wscript puts the buffertools.node file into 'build/default'.

I tested `npm install; node test.js` for node.js versions 0.4.12 and 0.6.14.  Each version had no output failure.

Idea taken from: https://github.com/brianmcd/contextify/commit/92b63ba0ecc1c971b267d3fcfec05570e434caa8#wscript

Best,
Barret
